### PR TITLE
Pass specific header path to have_func

### DIFF
--- a/ext/journald_native/extconf.rb
+++ b/ext/journald_native/extconf.rb
@@ -29,15 +29,17 @@ dir_config('systemd', HEADER_DIRS, LIB_DIRS)
 
 $CFLAGS = '-std=c11'
 
+SD_JOURNAL_HEADER = 'systemd/sd-journal.h'
+
 def have_funcs
   # check functions. redefine const list in sd_journal.h if changed
   %w(sd_journal_print sd_journal_sendv sd_journal_perror).inject(true) do |have_funcs, func|
-    have_funcs && have_func(func)
+    have_funcs && have_func(func, SD_JOURNAL_HEADER)
   end
 end
 
 # check headers
-have_header('systemd/sd-journal.h')
+have_header(SD_JOURNAL_HEADER)
 
 # first try to find funcs in systemd
 have_library('systemd')

--- a/lib/journald/native/version.rb
+++ b/lib/journald/native/version.rb
@@ -1,5 +1,5 @@
 module Journald
   module Native
-    VERSION = '1.0.9'
+    VERSION = '1.0.10'
   end
 end


### PR DESCRIPTION
Right now we're not specifying where have_func should look for a
function definition and I believe that have_func defaults to common
header files which probably do not include systemd header files.

I think this will work because have_header calls systemd/sd-journal.h
specifically and succeed when I attempt to build this gem against
Fedora 27.