### PR TITLE
Relative require not used for native library

### DIFF
--- a/lib/journald/native.rb
+++ b/lib/journald/native.rb
@@ -18,7 +18,7 @@
 #
 
 require 'journald/native/version'
-require_relative '../journald_native'
+require 'journald_native'
 
 module Journald
   module Native


### PR DESCRIPTION
Howdy. We are working on distribution packages for CentOS/RHEL and according to Fedora Packaging Ruby guildeline native extensions must go into separate directory. Here it how it looks like:

```
/usr/lib64/gems/ruby/journald-native-1.0.9
/usr/lib64/gems/ruby/journald-native-1.0.9/gem.build_complete
/usr/lib64/gems/ruby/journald-native-1.0.9/journald_native.so
/usr/share/gems/gems/journald-native-1.0.9
/usr/share/gems/gems/journald-native-1.0.9/COPYING.md
/usr/share/gems/gems/journald-native-1.0.9/LICENSE.txt
/usr/share/gems/gems/journald-native-1.0.9/lib
/usr/share/gems/gems/journald-native-1.0.9/lib/journald
/usr/share/gems/gems/journald-native-1.0.9/lib/journald/native
/usr/share/gems/gems/journald-native-1.0.9/lib/journald/native.rb
/usr/share/gems/gems/journald-native-1.0.9/lib/journald/native/version.rb
```

Note the `lib64` vs `share` directories. Now there is a load problem, because `require_relative` is used which ends up in searching in `/usr/share/` instead of `/usr/lib64` where it belongs in Red Hat compatible systems.

This patch avoids this behavior.

https://fedoraproject.org/wiki/Packaging:Ruby?rd=Packaging/Ruby